### PR TITLE
Add commont jest arguments to test command

### DIFF
--- a/commands/local/test.js
+++ b/commands/local/test.js
@@ -2,7 +2,21 @@ module.exports.command = 'test';
 module.exports.aliases = ['t'];
 module.exports.desc = 'Run your projects tests';
 
-module.exports.builder = function builder() {};
+module.exports.builder = function builder(yargs) {
+  yargs.option('testNamePattern=[query]', {
+    nargs: 1,
+    string: true,
+    requiresArg: true,
+    description: 'Run only tests with a name that matches the regex',
+  });
+
+  yargs.option('runInBand', {
+    description:
+      'Run all tests serially in the current process, rather than creating a worker pool of child processes that run tests. This can be useful for debugging.',
+  });
+
+  return yargs;
+};
 
 module.exports.handler = function handler() {
   require('jest').run();


### PR DESCRIPTION
Test command allows all jest cli flags to be passed through.  But it is
important to document via our `--help` output at least the basics to
elude to new users that it is available.