### PR TITLE
Move jest to project dependency.

### DIFF
--- a/commands/global/new.js
+++ b/commands/global/new.js
@@ -27,6 +27,7 @@ module.exports.handler = function handler(options) {
       keywords: ['codemod-cli'],
       devDependencies: {
         'codemod-cli': `^${pkg.version}`,
+        jest: pkg.devDependencies.jest,
       },
     },
     {

--- a/commands/local/test.js
+++ b/commands/local/test.js
@@ -19,5 +19,7 @@ module.exports.builder = function builder(yargs) {
 };
 
 module.exports.handler = function handler() {
-  require('jest').run();
+  const importCwd = require('import-cwd');
+
+  importCwd('jest').run();
 };

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "common-tags": "^1.8.0",
     "fs-extra": "^6.0.1",
+    "import-cwd": "^2.1.0",
     "import-local": "^1.0.0",
-    "jest": "^23.1.0",
     "jscodeshift": "^0.5.1",
     "pkg-up": "^2.0.0",
     "yargs": "^11.0.0"
@@ -27,6 +27,7 @@
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-prettier": "^2.6.0",
     "execa": "^0.10.0",
+    "jest": "^23.1.0",
     "lerna-changelog": "^0.8.0",
     "prettier": "^1.13.5",
     "qunit": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,6 +2323,18 @@ ignore@^3.3.3, ignore@^3.3.6:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
+import-cwd@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
+  dependencies:
+    import-from "^2.1.0"
+
+import-from@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
+  dependencies:
+    resolve-from "^3.0.0"
+
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"


### PR DESCRIPTION
In the future we will be shipping codemod-cli as a dependency of the project (so that it can defer to codemod-cli from its bin script).

This change is a simple precursor that allows `jest` to _not_ be a "production dependency" of either codemod-cli or the project itself.