### PR TITLE
Pass a file path to the runInlineTest

### DIFF
--- a/src/test-support.js
+++ b/src/test-support.js
@@ -36,7 +36,7 @@ function jscodeshiftTest(options) {
             runInlineTest(
               transform,
               {},
-              { source: fs.readFileSync(inputPath, 'utf8') },
+              { path: inputPath, source: fs.readFileSync(inputPath, 'utf8') },
               fs.readFileSync(outputPath, 'utf8')
             );
           });
@@ -45,7 +45,7 @@ function jscodeshiftTest(options) {
             runInlineTest(
               transform,
               {},
-              { source: fs.readFileSync(outputPath, 'utf8') },
+              { path: inputPath, source: fs.readFileSync(outputPath, 'utf8') },
               fs.readFileSync(outputPath, 'utf8')
             );
           });


### PR DESCRIPTION
This change unlocks testing of transforms which depends on a location of a file to be transformed. 

Currently with `runInlineTest` transforms only have access to the file `source` while transforms launched via jscodeshift [receive](https://github.com/facebook/jscodeshift/blob/595b15cda4f52673cad8fe3ae65c12e334966dbf/src/Worker.js#L131) both `source` and `path` options. So this change makes `runInlineTest` test helper behave more similar to jscodeshift.

----
Thanks a lot for the codemod-cli! it encouraged me to start writing my first codemod :smile: 