### PR TITLE
Ensure to use real path for `file.path` expectation.

### DIFF
--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -189,7 +189,8 @@ QUnit.module('codemod-cli', function(hooks) {
       QUnit.test(
         'transform should receive a file path in tests',
         wrap(function*(assert) {
-          const expectedPath = `${codemodProject.path()}/transforms/main/__testfixtures__/basic.input.js`;
+          const realCodemodProjectPath = fs.realpathSync(codemodProject.path());
+          const expectedPath = `${realCodemodProjectPath}/transforms/main/__testfixtures__/basic.input.js`;
 
           yield execa(EXECUTABLE_PATH, ['generate', 'codemod', 'main']);
 


### PR DESCRIPTION
Apparently, jscodeshift runs the provided path through `fs.realpathSync` but the return value from `broccoli-test-helper` hasn't passed through `realpathSync`.

On most linux / windows systems this doesn't matter, but on mac the `$TMPDIR` is references as `/var/folders/random-stuff/here/` but "really" is at `/private/var/folders/random-stuff/here/`.