### PR TITLE
Load an JSON file of jscodeshift options in test

### DIFF
--- a/src/test-support.js
+++ b/src/test-support.js
@@ -30,12 +30,13 @@ function jscodeshiftTest(options) {
         let testName = filename.replace(`.input${extension}`, '');
         let inputPath = path.join(details.fixtureDir, `${testName}.input${extension}`);
         let outputPath = path.join(details.fixtureDir, `${testName}.output${extension}`);
+        let optionsPath = path.join(details.fixtureDir, `${testName}.options.json`);
 
         describe(testName, function() {
           it('transforms correctly', function() {
             runInlineTest(
               transform,
-              {},
+              fs.pathExistsSync(optionsPath) ? JSON.parse(fs.readFileSync(optionsPath)) : {},
               { path: inputPath, source: fs.readFileSync(inputPath, 'utf8') },
               fs.readFileSync(outputPath, 'utf8')
             );
@@ -44,7 +45,7 @@ function jscodeshiftTest(options) {
           it('is idempotent', function() {
             runInlineTest(
               transform,
-              {},
+              fs.pathExistsSync(optionsPath) ? JSON.parse(fs.readFileSync(optionsPath)) : {},
               { path: inputPath, source: fs.readFileSync(outputPath, 'utf8') },
               fs.readFileSync(outputPath, 'utf8')
             );

--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -187,6 +187,47 @@ QUnit.module('codemod-cli', function(hooks) {
       );
 
       QUnit.test(
+        'transform should receive options from ${name}.options.json',
+        wrap(function*(assert) {
+          const realCodemodProjectPath = fs.realpathSync(codemodProject.path());
+          const expectedReplacement = 'AAAAHHHHHH';
+
+          yield execa(EXECUTABLE_PATH, ['generate', 'codemod', 'main']);
+
+          codemodProject.write({
+            transforms: {
+              main: {
+                'index.js': `
+                  const { getParser } = require('codemod-cli').jscodeshift;
+
+                  module.exports = function transformer(file, api, options) {
+                    const j = getParser(api);
+
+                    return j(file.source)
+                    .find(j.Literal)
+                    .forEach(path => {
+                      path.replace(
+                        j.stringLiteral(options.replaceAll)
+                      );
+                    })
+                    .toSource();
+                  }
+                `,
+                __testfixtures__: {
+                  'basic.input.js': 'var foo = "foo";',
+                  'basic.output.js': `var foo = "${expectedReplacement}";`,
+                  'basic.options.json': `{ "replaceAll": "${expectedReplacement}" }`,
+                },
+              },
+            },
+          });
+
+          let result = yield execa(EXECUTABLE_PATH, ['test']);
+          assert.equal(result.code, 0, 'exited with zero');
+        })
+      );
+
+      QUnit.test(
         'transform should receive a file path in tests',
         wrap(function*(assert) {
           const realCodemodProjectPath = fs.realpathSync(codemodProject.path());


### PR DESCRIPTION
This is obviously a terrible idea.

I'm trying to write a jscodeshift which requires arguments. Every person I've told this said: "Why would you need that?" Which seems kind of weird to me. Arguments are a generally useful concept.

Indeed jscodeshift has a way to [pass options to a transform](https://github.com/facebook/jscodeshift#options). Neat!

In this terrible implementation I've added the ability for jscodeshift to load JSON from `${testName}.options.json` as the options. There is probably a better way to factor this. For one, it would be nice to have the option of using JS instead of JSON.

A programmatic direction for this API (and maybe better) would be to require the author to invoke [the test code for each fixture set](https://github.com/mixonic/codemod-cli/blob/master/src/test-support.js#L29-L52) as an individual test. That way options could be passed from the test file. For example a test file might look like:

```js
'use strict';

const { runTransformTest } = require('codemod-cli');

runTransformTest({
  type: 'jscodeshift',
  name: 'my-transform',
  fixture: 'basic',
  options: { foo: 'baz' }
});

runTransformTest({
  type: 'jscodeshift',
  name: 'my-transform',
  fixture: 'basic',
  options: { foo: 'fwubadubdub' }
});

runTransformTest({
  type: 'jscodeshift',
  name: 'my-transform',
  fixture: 'complex'
});

runTransformTest({
  type: 'jscodeshift',
  name: 'another-transform',
  fixture: 'basic'
});
```