### PR TITLE
Add jest testEnvironment to package.json

### DIFF
--- a/commands/global/new.js
+++ b/commands/global/new.js
@@ -76,6 +76,9 @@ module.exports.handler = function handler(options) {
       devDependencies: {
         jest: pkg.devDependencies.jest,
       },
+      jest: {
+        testEnvironment: 'node',
+      },
     },
     {
       spaces: 2,


### PR DESCRIPTION
This is a fix for https://github.com/facebook/jest/issues/6766, which a fresh `codemod-cli` project also suffered from. (see https://github.com/facebook/jest/issues/6766#issuecomment-408381957)