### PR TITLE
Resolve jscodeshift binary path manually.

### DIFF
--- a/src/bin-support.js
+++ b/src/bin-support.js
@@ -10,7 +10,11 @@ function runTransform(binRoot, transformName, paths) {
     .then(paths => {
       let transformPath = path.join(binRoot, '..', 'transforms', transformName, 'index.js');
 
-      return execa('jscodeshift', ['-t', transformPath, '--extensions', 'js,ts', ...paths], {
+      let jscodeshiftPkg = require('jscodeshift/package');
+      let jscodeshiftPath = path.dirname(require.resolve('jscodeshift/package'));
+      let binPath = path.join(jscodeshiftPath, jscodeshiftPkg.bin.jscodeshift);
+
+      return execa(binPath, ['-t', transformPath, '--extensions', 'js,ts', ...paths], {
         stdio: 'inherit',
       });
     })


### PR DESCRIPTION
In some circumstances the `jscodeshift` binary is not found by `execa` (e.g. when using `npx`). This changes things around to manually resolve the binary path and use it directly.

Fixes https://github.com/rwjblue/ember-qunit-codemod/issues/140.