### PR TITLE
Updates travis.yml for generated projects

### DIFF
--- a/commands/global/new.js
+++ b/commands/global/new.js
@@ -90,7 +90,7 @@ module.exports.handler = function handler(options) {
       ---
       language: node_js
       node_js:
-        - "6"
+        - "10"
 
       sudo: false
       dist: trusty


### PR DESCRIPTION
The version of node in travis.yml is older, and actually causes errors in newly generated projects due to some transitive dependencies having a minimum node version of 8 specified for their engine.