### PR TITLE
Do not assume transform files are `.js`

### DIFF
--- a/src/test-support.js
+++ b/src/test-support.js
@@ -13,7 +13,7 @@ function transformDetails(options) {
   return {
     name: options.name,
     root,
-    transformPath: root + 'index.js',
+    transformPath: root + 'index',
     fixtureDir: root + '__testfixtures__/',
   };
 }


### PR DESCRIPTION
This makes it possible to write codemods with TypeScript using a `.ts` extension with `ts-jest`.