### PR TITLE
bin-support: Filter paths with extensions

### DIFF
--- a/src/bin-support.js
+++ b/src/bin-support.js
@@ -12,7 +12,9 @@ async function runTransform(binRoot, transformName, args, extensions = DEFAULT_E
   let { paths, options } = parseTransformArgs(args);
 
   try {
-    let foundPaths = await globby(paths);
+    let foundPaths = await globby(paths, {
+      expandDirectories: { extensions: extensions.split(',') },
+    });
     let transformPath = path.join(binRoot, '..', 'transforms', transformName, 'index.js');
 
     let jscodeshiftPkg = require('jscodeshift/package');


### PR DESCRIPTION
We can reduce the number of files sent to jscodeshift by filtering the paths with the `extensions` option.

Thus, we clean up the codemod's stack trace from an error shown on the screenshot:
![Capture d’écran 2019-08-05 à 14 09 59](https://user-images.githubusercontent.com/6677373/62464046-ddbd0400-b78b-11e9-81b8-2718761a3bb9.png)
