### PR TITLE
Removes `input` suffix from the path indicated during a test

### DIFF
--- a/src/test-support.js
+++ b/src/test-support.js
@@ -34,6 +34,7 @@ function jscodeshiftTest(options) {
       .forEach(filename => {
         let extension = path.extname(filename);
         let testName = filename.replace(`.input${extension}`, '');
+        let testInputPath = path.join(details.fixtureDir, `${testName}${extension}`);
         let inputPath = path.join(details.fixtureDir, `${testName}.input${extension}`);
         let outputPath = path.join(details.fixtureDir, `${testName}.output${extension}`);
         let optionsPath = path.join(details.fixtureDir, `${testName}.options.json`);
@@ -52,7 +53,7 @@ function jscodeshiftTest(options) {
             runInlineTest(
               transform,
               {},
-              { path: inputPath, source: fs.readFileSync(inputPath, 'utf8') },
+              { path: testInputPath, source: fs.readFileSync(inputPath, 'utf8') },
               fs.readFileSync(outputPath, 'utf8')
             );
           });
@@ -61,7 +62,7 @@ function jscodeshiftTest(options) {
             runInlineTest(
               transform,
               {},
-              { path: inputPath, source: fs.readFileSync(outputPath, 'utf8') },
+              { path: testInputPath, source: fs.readFileSync(outputPath, 'utf8') },
               fs.readFileSync(outputPath, 'utf8')
             );
           });

--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -203,7 +203,7 @@ QUnit.module('codemod-cli', function(hooks) {
 
       QUnit.test('transform should receive a file path in tests', async function(assert) {
         const realCodemodProjectPath = fs.realpathSync(codemodProject.path());
-        const expectedPath = `${realCodemodProjectPath}/transforms/main/__testfixtures__/basic.input.js`;
+        const expectedPath = `${realCodemodProjectPath}/transforms/main/__testfixtures__/basic.js`;
 
         await execa(EXECUTABLE_PATH, ['generate', 'codemod', 'main']);
 
@@ -240,7 +240,7 @@ QUnit.module('codemod-cli', function(hooks) {
 
       QUnit.test('transform should receive a subfolder file path in tests', async function(assert) {
         const realCodemodProjectPath = fs.realpathSync(codemodProject.path());
-        const expectedPath = `${realCodemodProjectPath}/transforms/main/__testfixtures__/foo/basic.input.js`;
+        const expectedPath = `${realCodemodProjectPath}/transforms/main/__testfixtures__/foo/basic.js`;
 
         await execa(EXECUTABLE_PATH, ['generate', 'codemod', 'main']);
 


### PR DESCRIPTION
This change will make writing accurate tests much easier. Possibly breaking.