### PR TITLE
Coerce boolean string args into proper Boolean values

### DIFF
--- a/src/options-support.js
+++ b/src/options-support.js
@@ -1,11 +1,19 @@
 const yargs = require('yargs');
 
+const BOOLEAN_VALUES = ['true', 'false'];
+function coerceArgs(value) {
+  if (BOOLEAN_VALUES.includes(value)) {
+    return value === 'true';
+  }
+  return value;
+}
+
 function parseTransformArgs(args) {
   let parsedArgs = yargs.parse(args);
   let paths = parsedArgs._;
   let options = Object.keys(parsedArgs).reduce((acc, key) => {
     if (!['_', '$0', 'help', 'version'].includes(key)) {
-      acc[key] = parsedArgs[key];
+      acc[key] = coerceArgs(parsedArgs[key]);
     }
     return acc;
   }, {});

--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -389,7 +389,7 @@ QUnit.module('codemod-cli', function(hooks) {
                     .find(j.Literal)
                     .forEach(path => {
                       path.replace(
-                        j.stringLiteral(options.biz + options.baz)
+                        j.stringLiteral(options.biz + options.baz + (options.someBoolean ? 'C' : 'D'))
                       );
                     })
                     .toSource();
@@ -408,11 +408,12 @@ QUnit.module('codemod-cli', function(hooks) {
           'A',
           '--baz',
           'B',
+          '--someBoolean=false',
           'foo/*ing.[jt]s',
         ]);
 
         assert.deepEqual(userProject.read(), {
-          foo: { 'something.js': `let blah = "AB";` },
+          foo: { 'something.js': `let blah = "ABD";` },
         });
       });
 


### PR DESCRIPTION
I discovered this when running ember-native-class-codemod and trying to disable some features.

[In the documentation](https://github.com/ember-codemods/ember-native-class-codemod#usage) it says you can disable features by setting a flag to `false`. For example, `--classic-decorator=false` will disable the insertion of the `@classic` decorator.

This doesn't work correctly because passing `--classic-decorator=false` actually gets transformed to `{ classicDecorator: 'false' }`. The `classicDecorator` value is a string value of `false` and therefore truthy.

I initially [posted a PR to ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod/pull/212) but I think it's better to fix the issue at the source here in codemod-cli.
