### PR TITLE
[docs] Update the readme blueprint for local usage

### DIFF
--- a/commands/global/new.js
+++ b/commands/global/new.js
@@ -40,7 +40,7 @@ module.exports.handler = async function handler(options) {
 
       ## Local Usage
       \`\`\`
-      npx ${process.cwd()}/${projectName}${cliPath} <TRANSFORM NAME> path/of/files/ or/some**/*glob.js
+      node .${cliPath} <TRANSFORM NAME> path/of/files/ or/some**/*glob.js
       \`\`\`
 
       ## Transforms

--- a/commands/global/new.js
+++ b/commands/global/new.js
@@ -16,6 +16,7 @@ module.exports.handler = async function handler(options) {
   const { stripIndent } = require('common-tags');
   const latestVersion = require('latest-version');
   const pkg = require('../../package.json');
+  const cliPath = '/bin/cli.js';
 
   fs.outputFileSync(
     projectName + '/README.md',
@@ -35,6 +36,11 @@ module.exports.handler = async function handler(options) {
 
       yarn global add ${projectName}
       ${projectName} <TRANSFORM NAME> path/of/files/ or/some**/*glob.js
+      \`\`\`
+
+      ## Local Usage
+      \`\`\`
+      npx ${process.cwd()}/${projectName}${cliPath} <TRANSFORM NAME> path/of/files/ or/some**/*glob.js
       \`\`\`
 
       ## Transforms
@@ -72,7 +78,7 @@ module.exports.handler = async function handler(options) {
         'update-docs': 'codemod-cli update-docs',
         coveralls: 'cat ./coverage/lcov.info | node node_modules/.bin/coveralls',
       },
-      bin: './bin/cli.js',
+      bin: `.${cliPath}`,
       keywords: ['codemod-cli'],
       dependencies: {
         'codemod-cli': `^${pkg.version}`,
@@ -239,7 +245,7 @@ module.exports.handler = async function handler(options) {
     `
   );
   fs.outputFileSync(
-    projectName + '/bin/cli.js',
+    `${projectName}${cliPath}`,
     stripIndent`
       #!/usr/bin/env node
       'use strict';

--- a/commands/local/generate/codemod.js
+++ b/commands/local/generate/codemod.js
@@ -70,6 +70,11 @@ module.exports.handler = function handler(options) {
       ${projectName} ${codemodName} path/of/files/ or/some**/*glob.js
       \`\`\`
 
+      ## Local Usage
+      \`\`\`
+      npx ${process.cwd()}/${projectName}/bin/cli.js ${codemodName} path/of/files/ or/some**/*glob.js
+      \`\`\`
+
       ## Input / Output
 
       <!--FIXTURES_TOC_START-->

--- a/commands/local/generate/codemod.js
+++ b/commands/local/generate/codemod.js
@@ -72,7 +72,7 @@ module.exports.handler = function handler(options) {
 
       ## Local Usage
       \`\`\`
-      npx ${process.cwd()}/${projectName}/bin/cli.js ${codemodName} path/of/files/ or/some**/*glob.js
+      node ./bin/cli.js ${codemodName} path/of/files/ or/some**/*glob.js
       \`\`\`
 
       ## Input / Output


### PR DESCRIPTION
We recently had an engineer who was not familiar with npx and could not figure out
how to run a new codemod locally.

I've updated the blueprint to make it clear to new users how to run a codemod locally before
publishing.