### PR TITLE
Drop node 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: install yarn
-      run: npm install -g yarn
     - name: install dependencies
       run: yarn install
     - name: linting
@@ -42,8 +40,6 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node }}
-    - name: install yarn
-      run: npm install --global yarn
     - name: install dependencies
       run: yarn
     - name: test
@@ -58,8 +54,6 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
-    - name: install yarn
-      run: npm install -g yarn
     - name: install dependencies
       run: yarn install --no-lockfile
     - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['^8.12.0', '10', '12']
+        node: ['10', '12', '13']
         os: [ubuntu-latest, macOS-latest]
 
     steps:

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,7 +15,7 @@ const pkgUp = require('pkg-up');
 function insideProject() {
   let nearestPackagePath = pkgUp.sync();
 
-  if (nearestPackagePath === null) {
+  if (!nearestPackagePath) {
     return false;
   }
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "walk-sync": "^2.0.2"
   },
   "engines": {
-    "node": "8.* || 10.* || >= 12"
+    "node": "10.* || >= 12"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Supercedes #76 

@rwjblue I was able to figure out what was causing `yarn` to fail in tests. In a spike I added `{ stdio: 'inherit' }` to the `execa` call to show the output of running `yarn`, which showed that apparently the previously symlinked node_modules folders were causing some trouble. See the [CI log output](https://github.com/simonihmig/codemod-cli/runs/765295324?check_suite_focus=true#step:5:29).

This PR takes your previous commit, and adds one to change the order of running `yarn` before symlinking.