### PR TITLE
Remove .travis.yml from newly generated projects.

### DIFF
--- a/commands/global/new.js
+++ b/commands/global/new.js
@@ -146,35 +146,6 @@ module.exports.handler = async function handler(options) {
   );
 
   fs.outputFileSync(
-    projectName + '/.travis.yml',
-    stripIndent`
-      ---
-      language: node_js
-      node_js:
-        - "8"
-
-      sudo: false
-      dist: trusty
-
-      cache:
-        yarn: true
-
-      before_install:
-        - curl -o- -L https://yarnpkg.com/install.sh | bash
-        - export PATH=$HOME/.yarn/bin:$PATH
-
-      install:
-        - yarn install
-
-      script:
-        - yarn lint
-        - yarn test:coverage
-
-      after_success:
-        - yarn coveralls
-    `
-  );
-  fs.outputFileSync(
     projectName + '/.github/workflows/ci.yml',
     stripIndent`
       name: CI

--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -69,7 +69,6 @@ QUnit.module('codemod-cli', function(hooks) {
         'ember-qunit-codemod/.github/workflows/ci.yml',
         'ember-qunit-codemod/.gitignore',
         'ember-qunit-codemod/.prettierrc',
-        'ember-qunit-codemod/.travis.yml',
         'ember-qunit-codemod/README.md',
         'ember-qunit-codemod/bin/',
         'ember-qunit-codemod/bin/cli.js',


### PR DESCRIPTION
IMHO, this is non-breaking as it is only about _new_ projects that are generated, not existing ones.