### PR TITLE
Added some more default options for jscodeshift command line args

### DIFF
--- a/src/options-support.js
+++ b/src/options-support.js
@@ -1,6 +1,14 @@
 const yargs = require('yargs');
 
-const jsCodeShiftOptions = ['ignore-config', 'ignore-pattern'];
+const jsCodeShiftOptions = [
+  'dry',
+  'ignore-config',
+  'ignore-pattern',
+  'print',
+  'run-in-band',
+  'silent',
+  'verbose',
+];
 
 function parseTransformArgs(args, codeShiftOptions = jsCodeShiftOptions) {
   let parsedArgs = yargs.parse(args);


### PR DESCRIPTION
@rwjblue I noticed that `--run-in-band` wasn't being passed to jscodeshift when running codemods via the codemod-cli. I've gotten around this by hardcoding the value locally, but seems that this (and a few other) jscodeshift args should be respected by default.