### PR TITLE
fix the break when running ember-template-recast

### DIFF
--- a/src/bin-support.js
+++ b/src/bin-support.js
@@ -48,6 +48,7 @@ async function runJsTransform(root, transformName, args, extensions = DEFAULT_JS
 async function runTemplateTransform(root, transformName, args) {
   const execa = require('execa');
   const chalk = require('chalk');
+  const path = require('path');
   const { parseTransformArgs } = require('./options-support');
   const { getTransformPath } = require('./transform-support');
 
@@ -56,10 +57,14 @@ async function runTemplateTransform(root, transformName, args) {
   try {
     let transformPath = getTransformPath(root, transformName);
     let binOptions = ['-t', transformPath, ...paths];
+    let templateRecastBinPath = path.join(
+      path.dirname(require.resolve('ember-template-recast/package.json')),
+      'bin',
+      'ember-template-recast.js'
+    );
 
-    return execa('ember-template-recast', binOptions, {
+    return execa(templateRecastBinPath, binOptions, {
       stdio: 'inherit',
-      preferLocal: true,
       env: {
         CODEMOD_CLI_ARGS: JSON.stringify(options),
       },

--- a/src/bin-support.js
+++ b/src/bin-support.js
@@ -57,11 +57,9 @@ async function runTemplateTransform(root, transformName, args) {
   try {
     let transformPath = getTransformPath(root, transformName);
     let binOptions = ['-t', transformPath, ...paths];
-    let templateRecastBinPath = path.join(
-      path.dirname(require.resolve('ember-template-recast/package.json')),
-      'bin',
-      'ember-template-recast.js'
-    );
+    let templateRecastDir = path.dirname(require.resolve('ember-template-recast/package.json'));
+    let templateRecastPkg = require('ember-template-recast/package');
+    let templateRecastBinPath = path.join(templateRecastDir, templateRecastPkg.bin);
 
     return execa(templateRecastBinPath, binOptions, {
       stdio: 'inherit',


### PR DESCRIPTION
### Description
Fix [issue 155](https://github.com/rwjblue/codemod-cli/issues/155). Change the bin entry for `ember-template-recast` for better compatibility.


### Test
```shell
# pass 23
# skip 0
# todo 0
# fail 0
✨  Done in 69.59s.
```