### PR TITLE
fix: supply file list to jscodeshift via stdin

### DIFF
--- a/src/bin-support.js
+++ b/src/bin-support.js
@@ -7,6 +7,8 @@ async function runJsTransform(root, transformName, args, extensions = DEFAULT_JS
   const execa = require('execa');
   const chalk = require('chalk');
   const path = require('path');
+  const { Readable } = require("stream")
+  const fs = require('fs');
   const { parseTransformArgs } = require('./options-support');
   const { getTransformPath } = require('./transform-support');
 
@@ -19,6 +21,7 @@ async function runJsTransform(root, transformName, args, extensions = DEFAULT_JS
     let transformPath = getTransformPath(root, transformName);
 
     let jscodeshiftPkg = require('jscodeshift/package');
+
     let jscodeshiftPath = path.dirname(require.resolve('jscodeshift/package'));
     let binPath = path.join(jscodeshiftPath, jscodeshiftPkg.bin.jscodeshift);
 
@@ -28,15 +31,26 @@ async function runJsTransform(root, transformName, args, extensions = DEFAULT_JS
       '--extensions',
       extensions,
       ...transformerOptions,
-      ...foundPaths,
+      '--stdin', // tell jscodeshift to read the list of files from stdin
     ];
 
-    return execa(binPath, binOptions, {
-      stdio: 'inherit',
+    let handle = execa(binPath, binOptions, {
+      stdout: 'inherit',
+      stderr: 'inherit',
+      stdin: 'pipe', // must be pipe for the below
       env: {
         CODEMOD_CLI_ARGS: JSON.stringify(options),
       },
     });
+
+    // https://github.com/ember-codemods/es5-getter-ember-codemod/issues/34
+    let pathsStream = new Readable();
+    pathsStream.push(foundPaths.join('\n'));
+    pathsStream.push(null);
+    pathsStream.pipe(handle.stdin);
+
+    return await handle;
+
   } catch (error) {
     console.error(chalk.red(error.stack)); // eslint-disable-line no-console
     process.exitCode = 1;

--- a/src/bin-support.js
+++ b/src/bin-support.js
@@ -7,8 +7,7 @@ async function runJsTransform(root, transformName, args, extensions = DEFAULT_JS
   const execa = require('execa');
   const chalk = require('chalk');
   const path = require('path');
-  const { Readable } = require("stream")
-  const fs = require('fs');
+  const { Readable } = require('stream');
   const { parseTransformArgs } = require('./options-support');
   const { getTransformPath } = require('./transform-support');
 
@@ -50,7 +49,6 @@ async function runJsTransform(root, transformName, args, extensions = DEFAULT_JS
     pathsStream.pipe(handle.stdin);
 
     return await handle;
-
   } catch (error) {
     console.error(chalk.red(error.stack)); // eslint-disable-line no-console
     process.exitCode = 1;


### PR DESCRIPTION
jscodeshift allows for file lists to be supplied via stdin, which is useful when the list of files is long enough that the max length for a command is exceeded. For projects with large numbers of files to codemod this limit is easy to hit.

This PR shifts codemod-cli to take the list of files obtained from `globby`, converts them into a `Readable` stream, and then pipes that tream to the execa process's stdin for jscodeshift to use.

See https://github.com/ember-codemods/es5-getter-ember-codemod/issues/34 for example failure