### PR TITLE
Allow alternate folder structures for codemod-cli project

### DIFF
--- a/commands/local/generate/codemod.js
+++ b/commands/local/generate/codemod.js
@@ -6,6 +6,11 @@ module.exports.builder = function builder(yargs) {
     .positional('codemod-name', {
       describe: 'the name of the codemod to generate',
     })
+    .option('codemod-dir', {
+      type: 'string',
+      describe: 'the path to the transform directory',
+      default: `./transforms/`,
+    })
     .option('type', {
       alias: 't',
       describe: 'choose the transform type',
@@ -16,13 +21,14 @@ module.exports.builder = function builder(yargs) {
 
 function jsHandler(options) {
   const fs = require('fs-extra');
+  const path = require('path');
   const { stripIndent } = require('common-tags');
   const importCwd = require('import-cwd');
   const generateFixture = require('./fixture').handler;
 
   let { codemodName } = options;
   let projectName = importCwd('./package.json').name;
-  let codemodDir = `${process.cwd()}/transforms/${codemodName}`;
+  let codemodDir = path.join(options.codemodDir, codemodName);
 
   fs.outputFileSync(
     `${codemodDir}/index.js`,
@@ -94,7 +100,12 @@ function jsHandler(options) {
     'utf8'
   );
 
-  generateFixture({ codemodName, fixtureName: 'basic', type: options.type });
+  generateFixture({
+    codemodName,
+    codemodDir: options.codemodDir,
+    fixtureName: 'basic',
+    type: options.type,
+  });
 }
 
 function hbsHandler(options) {
@@ -173,7 +184,12 @@ function hbsHandler(options) {
     'utf8'
   );
 
-  generateFixture({ codemodName, fixtureName: 'basic', type: options.type });
+  generateFixture({
+    codemodName,
+    codemodDir: options.codemodDir,
+    fixtureName: 'basic',
+    type: options.type,
+  });
 }
 
 module.exports.handler = function handler(options) {

--- a/commands/local/generate/codemod.js
+++ b/commands/local/generate/codemod.js
@@ -64,6 +64,7 @@ function jsHandler(options) {
 
       runTransformTest({ 
         name: '${codemodName}',
+        path: require.resolve('./index.js'),
       });
     `,
     'utf8'

--- a/commands/local/generate/codemod.js
+++ b/commands/local/generate/codemod.js
@@ -65,6 +65,7 @@ function jsHandler(options) {
       runTransformTest({ 
         name: '${codemodName}',
         path: require.resolve('./index.js'),
+        fixtureDir: \`\${__dirname}/__testfixtures__/\`,
       });
     `,
     'utf8'

--- a/commands/local/generate/fixture.js
+++ b/commands/local/generate/fixture.js
@@ -8,15 +8,21 @@ module.exports.builder = function builder(yargs) {
     })
     .positional('fixture-name', {
       describe: 'the name of the fixture to generate',
+    })
+    .option('codemod-dir', {
+      type: 'string',
+      describe: 'the path to the transform directory',
+      default: `./transforms/`,
     });
 };
 
 module.exports.handler = function handler(options) {
   const fs = require('fs-extra');
+  const path = require('path');
   const { getTransformType } = require('../../../src/transform-support');
 
   let { codemodName, fixtureName } = options;
-  let codemodDir = `${process.cwd()}/transforms/${codemodName}`;
+  let codemodDir = path.resolve(process.cwd(), path.join(options.codemodDir, codemodName));
   let fixturePath = `${codemodDir}/__testfixtures__/${fixtureName}`;
 
   let transformType = getTransformType(codemodDir);

--- a/src/bin-support.js
+++ b/src/bin-support.js
@@ -2,13 +2,12 @@
 
 const DEFAULT_JS_EXTENSIONS = 'js,ts';
 
-async function runJsTransform(root, transformName, args, extensions = DEFAULT_JS_EXTENSIONS) {
+async function runJsTransform(transformPath, args, extensions = DEFAULT_JS_EXTENSIONS) {
   const globby = require('globby');
   const execa = require('execa');
   const chalk = require('chalk');
   const path = require('path');
   const { parseTransformArgs } = require('./options-support');
-  const { getTransformPath } = require('./transform-support');
 
   let { paths, options, transformerOptions } = parseTransformArgs(args);
 
@@ -16,7 +15,6 @@ async function runJsTransform(root, transformName, args, extensions = DEFAULT_JS
     let foundPaths = await globby(paths, {
       expandDirectories: { extensions: extensions.split(',') },
     });
-    let transformPath = getTransformPath(root, transformName);
 
     let jscodeshiftPkg = require('jscodeshift/package');
     let jscodeshiftPath = path.dirname(require.resolve('jscodeshift/package'));
@@ -45,17 +43,15 @@ async function runJsTransform(root, transformName, args, extensions = DEFAULT_JS
   }
 }
 
-async function runTemplateTransform(root, transformName, args) {
+async function runTemplateTransform(transformPath, args) {
   const execa = require('execa');
   const chalk = require('chalk');
   const path = require('path');
   const { parseTransformArgs } = require('./options-support');
-  const { getTransformPath } = require('./transform-support');
 
   let { paths, options } = parseTransformArgs(args);
 
   try {
-    let transformPath = getTransformPath(root, transformName);
     let binOptions = ['-t', transformPath, ...paths];
     let templateRecastDir = path.dirname(require.resolve('ember-template-recast/package.json'));
     let templateRecastPkg = require('ember-template-recast/package');
@@ -85,9 +81,9 @@ async function runTransform(binRoot, transformName, args, extensions) {
 
   switch (type) {
     case 'js':
-      return runJsTransform(root, transformName, args, extensions);
+      return runJsTransform(transformPath, args, extensions);
     case 'hbs':
-      return runTemplateTransform(root, transformName, args);
+      return runTemplateTransform(transformPath, args);
     default:
       throw new Error(`Unknown type passed to runTransform: "${type}"`);
   }

--- a/src/test-support.js
+++ b/src/test-support.js
@@ -18,9 +18,7 @@ function testRunner(options, runTest) {
         cwd: details.fixtureDir,
         absolute: true,
       })
-      .map((entry) =>
-        entry.slice(entry.indexOf('__testfixtures__') + '__testfixtures__'.length + 1)
-      )
+      .map((entry) => entry.slice(details.fixtureDir.length))
       .forEach((filename) => {
         let extension = path.extname(filename);
         let testName = filename.replace(`.input${extension}`, '');

--- a/src/test-support/utils.js
+++ b/src/test-support/utils.js
@@ -4,7 +4,7 @@ function transformDetails(options) {
   const { getTransformType, getTransformPath } = require('../transform-support');
   const path = require('path');
 
-  let transformPath = getTransformPath(process.cwd(), options.name);
+  let transformPath = options.path ? options.path : getTransformPath(process.cwd(), options.name);
   let root = path.dirname(transformPath);
   let transformType = getTransformType(transformPath);
 

--- a/src/test-support/utils.js
+++ b/src/test-support/utils.js
@@ -7,13 +7,14 @@ function transformDetails(options) {
   let transformPath = options.path ? options.path : getTransformPath(process.cwd(), options.name);
   let root = path.dirname(transformPath);
   let transformType = getTransformType(transformPath);
+  let fixtureDir = options.fixtureDir ? options.fixtureDir : path.join(root, '__testfixtures__/');
 
   return {
     name: options.name,
     root,
     transformPath,
     transformType,
-    fixtureDir: path.join(root, '__testfixtures__/'),
+    fixtureDir,
   };
 }
 

--- a/src/transform-support.js
+++ b/src/transform-support.js
@@ -3,6 +3,11 @@
 function getTransformPath(root, transformName) {
   const path = require('path');
 
+  // transformName **IS** a valid path, no need to resolve manually
+  if (transformName.startsWith('.') || transformName.startsWith('/')) {
+    return transformName;
+  }
+
   return require.resolve(path.join(root, 'transforms', transformName));
 }
 

--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -158,7 +158,7 @@ QUnit.module('codemod-cli', function (hooks) {
         ]);
       });
 
-      QUnit.test('should generate a codemod in a custom directory', async function(assert) {
+      QUnit.test('should generate a codemod in a custom directory', async function (assert) {
         let result = await execa(EXECUTABLE_PATH, [
           'generate',
           'codemod',
@@ -259,8 +259,21 @@ QUnit.module('codemod-cli', function (hooks) {
       });
 
       QUnit.test('should pass for an empty codemod in a custom directory', async function (assert) {
-        await execa(EXECUTABLE_PATH, ['generate', 'codemod', 'main', '--codemod-dir', 'other-transform-path']);
-        await execa(EXECUTABLE_PATH, ['generate', 'fixture', 'main', 'this-dot-owner', '--codemod-dir', 'other-transform-path']);
+        await execa(EXECUTABLE_PATH, [
+          'generate',
+          'codemod',
+          'main',
+          '--codemod-dir',
+          'other-transform-path',
+        ]);
+        await execa(EXECUTABLE_PATH, [
+          'generate',
+          'fixture',
+          'main',
+          'this-dot-owner',
+          '--codemod-dir',
+          'other-transform-path',
+        ]);
 
         let result = await execa(EXECUTABLE_PATH, ['test']);
         assert.equal(result.exitCode, 0, 'exited with zero');
@@ -450,11 +463,18 @@ QUnit.module('codemod-cli', function (hooks) {
         foo: { 'something.js': 'let blah = bar', 'other.js': 'let blah = bar' },
       });
 
-      await execa(EXECUTABLE_PATH, ['generate', 'codemod', 'secondary', '--codemod-dir', 'other-dir'], {
-        cwd: codemodProject.path(),
-      });
+      await execa(
+        EXECUTABLE_PATH,
+        ['generate', 'codemod', 'secondary', '--codemod-dir', 'other-dir'],
+        {
+          cwd: codemodProject.path(),
+        }
+      );
 
-      await execa(codemodProject.path('bin/cli.js'), [codemodProject.path('./other-dir/secondary/index.js'), 'foo/*thing.js']);
+      await execa(codemodProject.path('bin/cli.js'), [
+        codemodProject.path('./other-dir/secondary/index.js'),
+        'foo/*thing.js',
+      ]);
 
       assert.deepEqual(userProject.read(), {
         foo: {

--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -444,6 +444,25 @@ QUnit.module('codemod-cli', function (hooks) {
         },
       });
     });
+
+    QUnit.test('works with custom codemod directory', async function (assert) {
+      userProject.write({
+        foo: { 'something.js': 'let blah = bar', 'other.js': 'let blah = bar' },
+      });
+
+      await execa(EXECUTABLE_PATH, ['generate', 'codemod', 'secondary', '--codemod-dir', 'other-dir'], {
+        cwd: codemodProject.path(),
+      });
+
+      await execa(codemodProject.path('bin/cli.js'), [codemodProject.path('./other-dir/secondary/index.js'), 'foo/*thing.js']);
+
+      assert.deepEqual(userProject.read(), {
+        foo: {
+          'something.js': 'let halb = rab',
+          'other.js': 'let blah = bar',
+        },
+      });
+    });
   });
 
   QUnit.module('programmatic API', function (hooks) {

--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -158,6 +158,27 @@ QUnit.module('codemod-cli', function (hooks) {
         ]);
       });
 
+      QUnit.test('should generate a codemod in a custom directory', async function(assert) {
+        let result = await execa(EXECUTABLE_PATH, [
+          'generate',
+          'codemod',
+          'main',
+          '--codemod-dir',
+          'other-dir',
+        ]);
+
+        assert.equal(result.exitCode, 0, 'exited with zero');
+        assert.deepEqual(walkSync(codemodProject.path('other-dir')), [
+          'main/',
+          'main/README.md',
+          'main/__testfixtures__/',
+          'main/__testfixtures__/basic.input.js',
+          'main/__testfixtures__/basic.output.js',
+          'main/index.js',
+          'main/test.js',
+        ]);
+      });
+
       QUnit.test('should generate a hbs codemod', async function (assert) {
         let result = await execa(EXECUTABLE_PATH, ['generate', 'codemod', 'main', '--type', 'hbs']);
 

--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -258,6 +258,14 @@ QUnit.module('codemod-cli', function (hooks) {
         assert.equal(result.exitCode, 0, 'exited with zero');
       });
 
+      QUnit.test('should pass for an empty codemod in a custom directory', async function (assert) {
+        await execa(EXECUTABLE_PATH, ['generate', 'codemod', 'main', '--codemod-dir', 'other-transform-path']);
+        await execa(EXECUTABLE_PATH, ['generate', 'fixture', 'main', 'this-dot-owner', '--codemod-dir', 'other-transform-path']);
+
+        let result = await execa(EXECUTABLE_PATH, ['test']);
+        assert.equal(result.exitCode, 0, 'exited with zero');
+      });
+
       QUnit.test('should fail when input and output do not match', async function (assert) {
         await execa(EXECUTABLE_PATH, ['generate', 'codemod', 'main']);
         await execa(EXECUTABLE_PATH, ['generate', 'fixture', 'main', 'this-dot-owner']);


### PR DESCRIPTION
- Add `--codemod-dir` command line flag to `codemod-cli generate`
- Add support for custom paths in `runTransformTest` (add `path` option)
- Allow `runTransform` to accept path to transform to run
- Allow specifying a custom fixture directory