### PR TITLE
add support for jscodeshift stdin option

### DIFF
--- a/src/options-support.js
+++ b/src/options-support.js
@@ -7,6 +7,7 @@ const jsCodeShiftOptions = [
   'print',
   'run-in-band',
   'silent',
+  'stdin',
   'verbose',
 ];
 


### PR DESCRIPTION
We are running into ENAMETOOLONG errors in some of our codebases when running the codemod.  We are able to address this by passing the filenames through as stdin but need to update the allowed options to support this jscodeshift functionality.